### PR TITLE
Few minor fixes

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -151,13 +151,13 @@ def generate_test_script(folder, num_tests, problem):
             '  esac\n'
             'done\n'
             '\n'
-            'if ! '+COMPILE_CMD+' {0}.cc; then\n'
+            'if ! '+COMPILE_CMD+' {0}.{1}; then\n'
             '    exit\n'
             'fi\n'
             'INPUT_NAME='+SAMPLE_INPUT+'\n'
             'OUTPUT_NAME='+SAMPLE_OUTPUT+'\n'
             'MY_NAME='+MY_OUTPUT+'\n'
-            'rm -R $MY_NAME* &>/dev/null\n').format(problem))
+            'rm -R $MY_NAME* &>/dev/null\n').format(problem, TEMPLATE.split('.')[1]))
         test.write(
             'for test_file in $INPUT_NAME*\n'
             'do\n'

--- a/parse.py
+++ b/parse.py
@@ -169,7 +169,7 @@ def generate_test_script(folder, num_tests, problem):
             '        echo Sample Input \#$test_case\n'
             '        cat $INPUT_NAME$test_case\n'
             '    else\n'
-            '        if diff --brief $MY_NAME$test_case $OUTPUT_NAME$test_case; then\n'
+            '        if diff --brief --ignore-trailing-space $MY_NAME$test_case $OUTPUT_NAME$test_case; then\n'
             '            echo {1}{3}Sample test \#$test_case: Accepted{2} {6}\n'
             '        else\n'
             '            echo {1}{4}Sample test \#$test_case: Wrong Answer{2} {6}\n'

--- a/parse.py
+++ b/parse.py
@@ -156,13 +156,13 @@ def generate_test_script(folder, num_tests, problem):
             'fi\n'
             'INPUT_NAME='+SAMPLE_INPUT+'\n'
             'OUTPUT_NAME='+SAMPLE_OUTPUT+'\n'
-            'MY_NAME='+MY_OUTPUT+'\n').format(problem))
+            'MY_NAME='+MY_OUTPUT+'\n'
+            'rm -R $MY_NAME* &>/dev/null\n').format(problem))
         test.write(
             'for test_file in $INPUT_NAME*\n'
             'do\n'
             '    i=$((${{#INPUT_NAME}}))\n'
             '    test_case=${{test_file:$i}}\n'
-            '    rm -R $MY_NAME*\n'
             '    if ! {5} ./a.out < $INPUT_NAME$test_case > $MY_NAME$test_case; then\n'
             '        echo {1}{4}Sample test \#$test_case: Runtime Error{2} {6}\n'
             '        echo ========================================\n'


### PR DESCRIPTION
Solves the following bugs: 

- If you use the code `for (int i : vec) cout << i << " ";` in a program, the diff in `test.sh` will show an error, because of the trailing space. => Simply ignore it. (Codeforces ignores them too). 

- During the first run of `./test.sh` there is an error message `rm: cannot remove 'my_output*': No such file or directory`. => Suppress the error message. 

- Also, don't delete the output files during each test-run. Once at the start of `./test.sh` should be enough. This way the user can afterwards see and manually check the output. 

- The file extension of the template has been ignored in `./test.sh`. 