### PR TITLE
Add Golang support

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+var DEBUG = "N"
+var DEBUG_BOOL = false
+
+func debug(args ...interface{}) {
+	if DEBUG_BOOL {
+		fmt.Fprintln(os.Stderr, args...)
+	}
+}
+
+func main() {
+	if DEBUG != "N" {
+		DEBUG_BOOL = true
+	}
+
+	var N int
+	fmt.Scan(&N)
+
+	debug(N)
+}

--- a/parse.py
+++ b/parse.py
@@ -15,10 +15,26 @@ from sys import argv
 from subprocess import call
 from functools import partial, wraps
 import re
- 
-# User modifiable constants:
-TEMPLATE='main.cc'
-COMPILE_CMD='g++ -g -std=c++0x -Wall $DBG'
+import argparse
+
+###########################
+# User modifiable constants
+###########################
+language_params = {
+        'c++14' : {
+            'TEMPLATE'    : 'main.cc',
+            'DEBUG_FLAGS' : '-DDEBUG',
+            'COMPILE_CMD' : 'g++ -g -std=c++14 -Wall $DBG',
+            'RUN_CMD'     : './a.out'
+            },
+        'go'    : {
+            'TEMPLATE'    : 'main.go',
+            'COMPILE_CMD' : 'go build $DBG -o a.out',
+            'DEBUG_FLAGS' : '''"-ldflags '-X=main.DEBUG=Y'"''',
+            'RUN_CMD'     : './a.out'
+            }
+        }
+
 SAMPLE_INPUT='input'
 SAMPLE_OUTPUT='output'
 MY_OUTPUT='my_output'
@@ -41,7 +57,7 @@ class CodeforcesProblemParser(HTMLParser):
         self.num_tests = 0
         self.testcase = None
         self.start_copy = False
-    
+
     def handle_starttag(self, tag, attrs):
         if tag == 'div':
             if attrs == [('class', 'input')]:
@@ -54,7 +70,7 @@ class CodeforcesProblemParser(HTMLParser):
         elif tag == 'pre':
             if self.testcase != None:
                 self.start_copy = True
- 
+
     def handle_endtag(self, tag):
         if tag == 'br':
             if self.start_copy:
@@ -67,17 +83,17 @@ class CodeforcesProblemParser(HTMLParser):
                 self.testcase.close()
                 self.testcase = None
                 self.start_copy = False
-    
+
     def handle_entityref(self, name):
         if self.start_copy:
             self.testcase.write(self.unescape(('&%s;' % name)).encode('utf-8'))
- 
+
     def handle_data(self, data):
         if self.start_copy:
             self.testcase.write(data.encode('utf-8'))
             self.end_line = False
 
-# Contest parser.  
+# Contest parser.
 class CodeforcesContestParser(HTMLParser):
 
     def __init__(self, contest):
@@ -89,7 +105,7 @@ class CodeforcesContestParser(HTMLParser):
         self.problem_name = ''
         self.problems = []
         self.problem_names = []
-    
+
     def handle_starttag(self, tag, attrs):
         if self.name == '' and attrs == [('style', 'color: black'), ('href', '/contest/%s' % (self.contest))]:
                 self.start_contest = True
@@ -101,7 +117,7 @@ class CodeforcesContestParser(HTMLParser):
                 if search is not None:
                     self.problems.append(search.group(0).split("'")[-2])
                     self.start_problem = True
- 
+
     def handle_endtag(self, tag):
         if tag == 'a' and self.start_contest:
             self.start_contest = False
@@ -109,23 +125,23 @@ class CodeforcesContestParser(HTMLParser):
             self.problem_names.append(self.problem_name)
             self.problem_name = ''
             self.start_problem = False
- 
+
     def handle_data(self, data):
         if self.start_contest:
             self.name = data
         elif self.start_problem:
             self.problem_name += data
-        
+
 # Parses each problem page.
 def parse_problem(folder, contest, problem):
     url = 'http://codeforces.com/contest/%s/problem/%s' % (contest, problem)
     html = urlopen(url).read()
     parser = CodeforcesProblemParser(folder)
-    parser.feed(html.decode('utf-8')) 
+    parser.feed(html.decode('utf-8'))
     # .encode('utf-8') Should fix special chars problems?
     return parser.num_tests
 
-# Parses the contest page.  
+# Parses the contest page.
 def parse_contest(contest):
     url = 'http://codeforces.com/contest/%s' % (contest)
     html = urlopen(url).read()
@@ -134,7 +150,9 @@ def parse_contest(contest):
     return parser
 
 # Generates the test script.
-def generate_test_script(folder, num_tests, problem):
+def generate_test_script(folder, language, num_tests, problem):
+    param = language_params[language]
+
     with open(folder + 'test.sh', 'w') as test:
         test.write(
             ('#!/bin/bash\n'
@@ -143,7 +161,7 @@ def generate_test_script(folder, num_tests, problem):
             '  case $opt in\n'
             '    d)\n'
             '      echo "-d was selected; compiling in DEBUG mode!" >&2\n'
-            '      DBG="-DDEBUG"\n'
+            '      DBG=' + param["DEBUG_FLAGS"] +'\n'
             '      ;;\n'
             '    \?)\n'
             '      echo "Invalid option: -$OPTARG" >&2\n'
@@ -151,19 +169,19 @@ def generate_test_script(folder, num_tests, problem):
             '  esac\n'
             'done\n'
             '\n'
-            'if ! '+COMPILE_CMD+' {0}.{1}; then\n'
+            'if ! ' + param["COMPILE_CMD"] +' {0}.{1}; then\n'
             '    exit\n'
             'fi\n'
             'INPUT_NAME='+SAMPLE_INPUT+'\n'
             'OUTPUT_NAME='+SAMPLE_OUTPUT+'\n'
             'MY_NAME='+MY_OUTPUT+'\n'
-            'rm -R $MY_NAME* &>/dev/null\n').format(problem, TEMPLATE.split('.')[1]))
+            'rm -R $MY_NAME* &>/dev/null\n').format(problem, param["TEMPLATE"].split('.')[1]))
         test.write(
             'for test_file in $INPUT_NAME*\n'
             'do\n'
             '    i=$((${{#INPUT_NAME}}))\n'
             '    test_case=${{test_file:$i}}\n'
-            '    if ! {5} ./a.out < $INPUT_NAME$test_case > $MY_NAME$test_case; then\n'
+            '    if ! {5} {run_cmd} < $INPUT_NAME$test_case > $MY_NAME$test_case; then\n'
             '        echo {1}{4}Sample test \#$test_case: Runtime Error{2} {6}\n'
             '        echo ========================================\n'
             '        echo Sample Input \#$test_case\n'
@@ -186,35 +204,42 @@ def generate_test_script(folder, num_tests, problem):
             '        fi\n'
             '    fi\n'
             'done\n'
-            .format(num_tests, BOLD, NORM, GREEN_F, RED_F, TIME_CMD, TIME_AP))
+            .format(num_tests, BOLD, NORM, GREEN_F, RED_F, TIME_CMD, TIME_AP, run_cmd=param["RUN_CMD"]))
     call(['chmod', '+x', folder + 'test.sh'])
 
-# Main function. 
+
+# Main function.
 def main():
     print (VERSION)
-    if(len(argv) < 2):
-        print('USAGE: ./parse.py 512')
-        return
-    contest = argv[1]
-    
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--language', '-l', default="c++14", help="The programming language you want to use "
+            "(c++14, go)")
+    parser.add_argument('contest', help="")
+    args = parser.parse_args()
+
+    contest = args.contest
+    language = args.language
+
     # Find contest and problems.
-    print ('Parsing contest %s, please wait...' % contest)
+    print ('Parsing contest %s for language %s, please wait...' % (contest, language))
     content = parse_contest(contest)
     print (BOLD+GREEN_F+'*** Round name: '+content.name+' ***'+NORM)
     print ('Found %d problems!' % (len(content.problems)))
-    
+
     # Find problems and test cases.
+    TEMPLATE = language_params[language]["TEMPLATE"]
     for index, problem in enumerate(content.problems):
         print ('Downloading Problem %s: %s...' % (problem, content.problem_names[index]))
-        folder = '%s/%s/' % (contest, problem)
+        folder = '%s-%s/%s/' % (contest, language, problem)
         call(['mkdir', '-p', folder])
-        call(['cp', '-n', TEMPLATE, '%s/%s/%s.%s' % (contest, problem, problem, TEMPLATE.split('.')[1])])
+        call(['cp', '-n', TEMPLATE, '%s/%s.%s' % (folder, problem, TEMPLATE.split('.')[1])])
         num_tests = parse_problem(folder, contest, problem)
         print('%d sample test(s) found.' % num_tests)
-        generate_test_script(folder, num_tests, problem)
+        generate_test_script(folder, language, num_tests, problem)
         print ('========================================')
-        
+
     print ('Use ./test.sh to run sample tests in each directory.')
- 
+
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Added go main file that supports debug output flag.
Added argparse to make programming language selectable from command-line.
Added language suffix to folder.
Removed trailing whitespace.

Resolves #8.

Notes:
- There is a commit that adjusted c++11 down to c++0x. Do we want to keep that behavior?
- I have not tested this very thoroughly yet.
- This only adds support for Go. Rust and Python should be relatively simple after these changes, however.