### PR TITLE
add --language=kotlin

### DIFF
--- a/main.kt
+++ b/main.kt
@@ -1,0 +1,15 @@
+var _debug = false;
+fun <T> debug(vararg vals: T): Unit {
+    if (!_debug) { return }
+    for (v in vals) { System.err.print(v); System.err.print(" ") }
+    System.err.println()
+}
+
+fun main(args: Array<String>) {
+    if (args.size > 0 && args[0] == "-d") {
+        _debug = true;
+    }
+
+    val n = readLine()!!.toInt()
+    val (a, b) = readLine()!!.split(' ').map(String::toLong)
+}

--- a/parse.py
+++ b/parse.py
@@ -32,7 +32,13 @@ language_params = {
             'COMPILE_CMD' : 'go build $DBG -o a.out',
             'DEBUG_FLAGS' : '''"-ldflags '-X=main.DEBUG=Y'"''',
             'RUN_CMD'     : './a.out'
-            }
+            },
+        'kotlin'    : {
+            'TEMPLATE'    : 'main.kt',
+            'COMPILE_CMD' : 'kotlinc -include-runtime -d out.jar',
+            'DEBUG_FLAGS' : "-d",
+            'RUN_CMD'     : 'java -jar out.jar $DBG'
+            },
         }
 
 SAMPLE_INPUT='input'


### PR DESCRIPTION
Hi,
looks like I just can't stop myself from tinkering with new languages...

I hope others will also enjoy using Kotlin in codeforces.

Commit message:
```
Added main.kt as starting point with example for stdin parsing.
Discussions online claim that readline is faster than Scanner but I
haven't tested that.

Debug mode for Kotlin uses a runtime flag for now.
I'd rather have a compile-time flag like in C++.
However, I don't think Java supports that. Please help...
```