### PR TITLE
Add a fix for problems with 2 characters

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -117,7 +117,7 @@ class CodeforcesContestParser(HTMLParser):
                 self.start_contest = True
         elif tag == 'option':
             if len(attrs) == 1:
-                regexp = re.compile(r"'[A-Z]'") # The attrs will be something like: ('value', 'X')
+                regexp = re.compile(r"'[A-Z][0-9]?'") # The attrs will be something like: ('value', 'X'), or ('value', 'X1')
                 string = str(attrs[0])
                 search = regexp.search(string)
                 if search is not None:


### PR DESCRIPTION
https://codeforces.com/contest/1304/ had two problems that broke the parser - F1 and F2. Parser parsed problem A-E correctly and ignored F1 and F2. 

This patch will fix the issue if future problems are named in this unconventional format.